### PR TITLE
Adding missing dependency for zlib-dev

### DIFF
--- a/vagrant/build/Dockerfile
+++ b/vagrant/build/Dockerfile
@@ -18,6 +18,8 @@ RUN yum makecache && yum install -y curl \
   scl-utils \
   centos-release-scl-rh
 
+RUN yum install zlib-devel -y
+
 RUN yum install -y ruby193 ruby193-ruby-devel python27
 
 RUN scl enable ruby193 "gem install gauntlt --no-ri --no-rdoc"


### PR DESCRIPTION
Build of the docker image was failing when trying to provision via `vagrant up build` complaining about missing zlib-dev dependency.

Adding this package allowed provisioning to complete successfully.